### PR TITLE
Fix warning of mix: "please use parentheses to remove the ambiguity"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule ElixirV8.Mixfile do
     [app: :elixir_v8,
      version: "0.2.2",
      elixir: "~> 1.2",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
I get this without this change:

```
[pig@localhost elixir_v8]$ mix deps.get
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:12

(...)
```